### PR TITLE
SS-8244: Reconnect if necessary on connection stability verification

### DIFF
--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -238,8 +238,7 @@ class DFUAdapter(BLEDriverObserver, BLEAdapterObserver):
 
         """
         logger.info("Checking connection stability")
-        retries = DFUAdapter.CONNECTION_ATTEMPTS
-        while retries:
+        for _ in range(DFUAdapter.CONNECTION_ATTEMPTS):
             self.conn_handle = self.evt_sync.wait('connected', timeout=30)
             if self.conn_handle is None:
                 logger.warning("Could not connect. Restarting adapter")
@@ -247,8 +246,8 @@ class DFUAdapter(BLEDriverObserver, BLEAdapterObserver):
                 self.adapter.driver.ble_gap_scan_start()
             else:
                 if self.evt_sync.wait('disconnected', timeout=1) is not None:
-                    logger.warning("Received unexpected disconnect event, "
-                                   "trying to re-connect to: {}".format(self.target_device_addr))
+                    logger.warning(f"Received unexpected disconnect event, "
+                                   f"trying to re-connect to: {self.target_device_addr}")
                     time.sleep(1)
                     self.adapter.connect(address=self.target_device_addr_type,
                                          conn_params=self.conn_params)
@@ -256,8 +255,6 @@ class DFUAdapter(BLEDriverObserver, BLEAdapterObserver):
 
                 logger.info("Connection successful")
                 return
-
-            retries -= 1
 
         self.adapter.driver.ble_gap_scan_stop()
         raise Exception("Connection Failure - Device not found!")

--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -231,33 +231,33 @@ class DFUAdapter(BLEDriverObserver, BLEAdapterObserver):
 
     def verify_stable_connection(self):
         """ Verify connection event, and verify that unexpected disconnect
-         events are not received.
+         events are not received. Reconnect if necessary.
 
         Returns:
             True if connected, else False.
 
         """
-        self.conn_handle = self.evt_sync.wait('connected', timeout=30)
-        if self.conn_handle is not None:
-            retries = DFUAdapter.CONNECTION_ATTEMPTS
-            while retries:
-                if self.evt_sync.wait('disconnected', timeout=1) is None:
-                    break
-
-                logger.warning("Received unexpected disconnect event, "
-                               "trying to re-connect to: {}".format(self.target_device_addr))
-                time.sleep(1)
-
-                self.adapter.connect(address=self.target_device_addr_type,
-                                     conn_params=self.conn_params)
-                self.conn_handle = self.evt_sync.wait('connected')
-                retries -= 1
+        logger.info("Checking connection stability")
+        retries = DFUAdapter.CONNECTION_ATTEMPTS
+        while retries:
+            self.conn_handle = self.evt_sync.wait('connected', timeout=30)
+            if self.conn_handle is None:
+                logger.warning("Could not connect. Restarting adapter")
+                self.adapter.driver.ble_gap_scan_stop()
+                self.adapter.driver.ble_gap_scan_start()
             else:
                 if self.evt_sync.wait('disconnected', timeout=1) is not None:
-                    raise Exception("Failure - Connection failed due to 0x3e")
+                    logger.warning("Received unexpected disconnect event, "
+                                   "trying to re-connect to: {}".format(self.target_device_addr))
+                    time.sleep(1)
+                    self.adapter.connect(address=self.target_device_addr_type,
+                                         conn_params=self.conn_params)
+                    return
 
-            logger.info("Successfully Connected")
-            return
+                logger.info("Connection successful")
+                return
+
+            retries -= 1
 
         self.adapter.driver.ble_gap_scan_stop()
         raise Exception("Connection Failure - Device not found!")

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.0.4.dev0"
+NRFUTIL_VERSION = "6.0.2"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.0.2"
+NRFUTIL_VERSION = "6.0.4.dev0"

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ class NoseTestCommand(TestCommand):
 
 setup(
     name="nrfutil-bluez",
-    version="6.0.4.dev0",
+    version="6.0.4.dev1",
     license="Modified BSD License",
     author="Nordic Semiconductor ASA",
     url="https://github.com/NordicSemiconductor/pc-nrfutil",

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ class NoseTestCommand(TestCommand):
 
 setup(
     name="nrfutil-bluez",
-    version="6.0.3",
+    version="6.0.4.dev0",
     license="Modified BSD License",
     author="Nordic Semiconductor ASA",
     url="https://github.com/NordicSemiconductor/pc-nrfutil",


### PR DESCRIPTION
This pull request handles the situation, when connection handle is not present on the entrance to the function.

It slightly refactors the logic of connection attempts and restarts the adapter, when connection handle is not present.

Before this change I had a reproduction rate of DFU functional tests instability of over 3% (31/967 failed).
After this change reproduction rate is 0% (0/237).
So it seems, that this change helped in bluez connection stabilization.