### PR TITLE
Ss 10029 restrict protobuf to compatible version

### DIFF
--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.0.2"
+NRFUTIL_VERSION = "6.0.3"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.0.3"
+NRFUTIL_VERSION = "6.0.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ intelhex
 libusb1
 pc_ble_driver_py >= 0.14.1
 piccata
-protobuf
+protobuf < 4.0.0
 pyserial
 pyspinel >= 1.0.0a3
 pyyaml

--- a/sca_pipeline.groovy
+++ b/sca_pipeline.groovy
@@ -7,7 +7,7 @@
 // During the first launch, you have to enter ALTERNATIVE_VERSION parameter.
 
 
-@Library('JenkinsMain@2.16.15')_
+@Library('JenkinsMain@2.19.17')_
 
 
 pipelinePythonSCA(

--- a/sca_pipeline.groovy
+++ b/sca_pipeline.groovy
@@ -18,4 +18,5 @@ pipelinePythonSCA(
     installFromSetup: true,
     runPipCheck: true,
     runUnitTests: false,
+    credentials: '1479b83d-f7b2-4823-8105-549616393cc5'
 )

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ class NoseTestCommand(TestCommand):
 
 setup(
     name="nrfutil-bluez",
-    version="6.0.6",
+    version=version.NRFUTIL_VERSION,
     license="Modified BSD License",
     author="Nordic Semiconductor ASA",
     url="https://github.com/NordicSemiconductor/pc-nrfutil",


### PR DESCRIPTION
Taking the restriction on `protobuf` version from the upstream (because of e.g. `nordicsemi/dfu/dfu_cc_pb2.py`). We already enforce the same in our repositories that use the `nrfutil`.

The SCA score is red because the /master branch is not yet using the new mechanism for storing SCA scores. Should fix itself after PR merge.