### PR TITLE
Ss 9957 generic handling of operation timeouts during sending the DFU image

### DIFF
--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -586,13 +586,13 @@ class DfuTransportBle(DfuTransport):
                     response['crc'] = self.__stream_data(data=data, crc=response['crc'], offset=current_offset)
                     self.__execute()
                 except ValidationException as error:
-                    logger.critical("BLE: ValidationException Error occurred during firmware send at "
+                    logger.critical("BLE: ValidationException Error occurred during sending firmware chunk at "
                                     f"attempt {r + 1}: {error}")
                     continue
                 except NordicSemiException as error:
-                    if "Timeout: operation - CalcChecSum" in error.msg:
-                        logger.critical("BLE: Timeout: operation - CalcChecSum Error occurred during firmware send at "
-                                        f"attempt {r + 1}. Trying to reconnect")
+                    if "Timeout: operation" in error.msg:
+                        logger.critical(f"BLE: Operation timeout error occurred during sending firmware "
+                                        f"chunk at attempt {r + 1}: {error}. Trying to reconnect")
                         self.close()
                         self.open()
                         response = self.__select_data()

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.8.dev0"
+NRFUTIL_VERSION = "6.1.8"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.7"
+NRFUTIL_VERSION = "6.1.8.dev0"


### PR DESCRIPTION
This PR adds generic handling of timeout operation errors (caused by the disconnect) during sending the DFU image.
Confirmed that it works fine for the recently observed errors during the DFU tests:
- `Timeout: operation - CalcChecSum`
```
[2022-11-24T18:12:36.773Z]     When we perform DFU to '2.21.2' firmware version over BLE in 'provisioned' state                        # steps/dfu_steps.py:344
[2022-11-24T18:14:13.418Z] 18:14:03.963 CRITICAL dfu_transport_bl:594  - BLE: Operation timeout error occurred during sending firmware chunk at attempt 1: Timeout: operation - CalcChecSum. Trying to reconnect
[2022-11-24T18:14:13.418Z] 18:14:11.200 CRITICAL dfu_transport_bl:600  - BLE: Response offset is the same as the current offset. Trying again to send the whole data.
```
-  `Timeout: operation - CreateObject`
```
[2022-11-24T19:28:10.026Z]     When we perform DFU to '2.21.2' firmware version over BLE in 'provisioned' state                        # steps/dfu_steps.py:344
[2022-11-24T19:29:46.695Z] 19:29:41.932 CRITICAL dfu_transport_bl:594  - BLE: Operation timeout error occurred during sending firmware chunk at attempt 1: Timeout: operation - CreateObject. Trying to reconnect
[2022-11-24T19:29:50.033Z] 19:29:49.372 CRITICAL dfu_transport_bl:600  - BLE: Response offset is the same as the current offset. Trying again to send the whole data.
```
Full logs:
https://jenkins.silvair.lan/job/FW-Test/job/SS-9957_fix_dfu_test_timeout_on_create_object/9/consoleText