### PR TITLE
Ss 9946 add support for dfu abort fault

### DIFF
--- a/nordicsemi/dfu/dfu_faults.py
+++ b/nordicsemi/dfu/dfu_faults.py
@@ -27,7 +27,7 @@ class DFUStage:
 
     @progress.setter
     def progress(self, value: float):
-        self._progress = min(value, 100)
+        self._progress = min(100.0, max(0.0, value))
 
 
 class DFUStageName(Enum):

--- a/nordicsemi/dfu/dfu_faults.py
+++ b/nordicsemi/dfu/dfu_faults.py
@@ -26,7 +26,7 @@ class DFUStage:
         return self._progress
 
     @progress.setter
-    def progress(self, value):
+    def progress(self, value: float):
         self._progress = min(value, 100)
 
 

--- a/nordicsemi/dfu/dfu_faults.py
+++ b/nordicsemi/dfu/dfu_faults.py
@@ -13,7 +13,11 @@ class DFUFaultType(Enum):
 
 @dataclass
 class DFUStage:
-    """ Class for keeping DFU Stage details """
+    """
+    Class for keeping DFU Stage details:
+    - name: name of the DFU stage. E.g. DFUStageName.INIT_PACKET
+    - progress: DFU stage progress given as a percentage value in range 0-100 %
+    """
     name: Optional[DFUStageName] = None
     progress: float = 0
 

--- a/nordicsemi/dfu/dfu_faults.py
+++ b/nordicsemi/dfu/dfu_faults.py
@@ -83,7 +83,7 @@ class DFUFaultsFactory:
         return DFUFault(DFUFaultType.CRC_VALIDATION, target_dfu_stage, delay_s, callback_function)
 
     @staticmethod
-    def power_off_fault(target_dfu_stage: DFUStage, delay_s: float, power_cycle_callback: Callable) -> DFUFault:
+    def create_power_off_fault(target_dfu_stage: DFUStage, delay_s: float, power_cycle_callback: Callable) -> DFUFault:
         """
         Create fault that simulates Power Off Error.
 
@@ -146,16 +146,4 @@ class DFUFaultManager:
         fault = self._get_fault(fault_type)
         if fault is not None:
             return fault.call_fault(current_dfu_stage)
-        return None
-
-    def on_crc_validation(self, current_dfu_stage: DFUStage) -> Optional[DFUFault]:
-        """
-        Function that should be called on CRC Validation.
-
-        :param current_dfu_stage: Current DFU Stage
-        :return DFUFault object if the fault was called else None
-        """
-        crc_validation_fault = self._get_fault(DFUFaultType.CRC_VALIDATION)
-        if crc_validation_fault is not None:
-            return crc_validation_fault.call_fault(current_dfu_stage)
         return None

--- a/nordicsemi/dfu/dfu_faults.py
+++ b/nordicsemi/dfu/dfu_faults.py
@@ -19,7 +19,15 @@ class DFUStage:
     - progress: DFU stage progress given as a percentage value in range 0-100 %
     """
     name: Optional[DFUStageName] = None
-    progress: float = 0
+    _progress: float = 0
+
+    @property
+    def progress(self):
+        return self._progress
+
+    @progress.setter
+    def progress(self, value):
+        self._progress = min(value, 100)
 
 
 class DFUStageName(Enum):

--- a/nordicsemi/dfu/dfu_faults.py
+++ b/nordicsemi/dfu/dfu_faults.py
@@ -1,6 +1,5 @@
 from __future__ import annotations  # enabling support for defining typing for self inside the DFUFault class
 
-from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, Optional
 
@@ -11,23 +10,27 @@ class DFUFaultType(Enum):
     ABORT = "ABORT"
 
 
-@dataclass
 class DFUStage:
     """
     Class for keeping DFU Stage details:
     - name: name of the DFU stage. E.g. DFUStageName.INIT_PACKET
     - progress: DFU stage progress given as a percentage value in range 0-100 %
     """
-    name: Optional[DFUStageName] = None
-    _progress: float = 0
+    def __init__(self, name: Optional[DFUStageName] = None, progress: float = 0.0):
+        self.name = name
+        self._progress = self._clip_progress(progress)
 
     @property
-    def progress(self):
+    def progress(self) -> float:
         return self._progress
 
     @progress.setter
     def progress(self, value: float):
-        self._progress = min(100.0, max(0.0, value))
+        self._progress = self._clip_progress(value)
+
+    @staticmethod
+    def _clip_progress(value: float) -> float:
+        return min(100.0, max(0.0, value))
 
 
 class DFUStageName(Enum):

--- a/nordicsemi/dfu/dfu_faults.py
+++ b/nordicsemi/dfu/dfu_faults.py
@@ -1,49 +1,43 @@
 from __future__ import annotations  # enabling support for defining typing for self inside the DFUFault class
+
+from dataclasses import dataclass
 from enum import Enum
-from time import time
 from typing import Callable, Optional
 
 
 class DFUFaultType(Enum):
     """ Enumerator class representing all available types of fault """
     CRC_VALIDATION = "CRC VALIDATION"
-    POWER_OFF = "POWER OFF"
     ABORT = "ABORT"
 
 
-class DFUStage(Enum):
-    """ Enumerator class representing all available DFU Stages """
+@dataclass
+class DFUStage:
+    """ Class for keeping DFU Stage details """
+    name: Optional[DFUStageName] = None
+    progress: float = 0
+
+
+class DFUStageName(Enum):
+    """ Enumerator class representing all available DFU Stage Names"""
     INIT_PACKET = "INIT PACKET"
     FIRMWARE_UPDATE = "FIRMWARE UPDATE"
-    AFTER_FIRMWARE_UPDATE = "AFTER FIRMWARE UPDATE"
 
 
 class DFUFault:
     """ DFU Fault class that contains all the details about the fault that is to be simulated """
-    def __init__(self, fault_type: DFUFaultType, target_dfu_stage: DFUStage, delay_s: Optional[float] = 0,
+    def __init__(self, fault_type: DFUFaultType, target_dfu_stage: DFUStage,
                  callback_function: Optional[Callable] = None):
         """
         Construct DFU fault object.
 
         :param fault_type: type of fault to generate
-        :param target_dfu_stage: desired DFU stage during which the fault should be generated
-        :param delay_s: delay in seconds (counted from first possible fault call in the target DFU stage) after which
-                        fault should be generated. None to generate fault on every possible call (permanent fault).
-                        NOTE: Delay parameter assumes that the call_fault method is called repeatedly during the
-                              dfu procedure (e.g. after sending each data chunk). This is needed to calculate the
-                              elapsed DFU stage time. When the time is higher or equal to the delay the the fault is
-                              generated.
+        :param target_dfu_stage: desired DFU stage (name and progress) during which the fault should be generated
         :param callback_function: optional function that will be called when fault should occur
         """
-        if delay_s is not None:
-            assert delay_s >= 0, "Delay must be higher or equal to 0."
-
         self.fault_type = fault_type
         self.target_dfu_stage = target_dfu_stage
-        self.delay_s = delay_s
         self.callback_function = callback_function
-        self._elapsed_time = 0
-        self._first_call_time = None
         self.called = False
 
     def call_fault(self, current_dfu_stage: DFUStage) -> Optional[DFUFault]:
@@ -53,11 +47,8 @@ class DFUFault:
         :param current_dfu_stage: current DFU Stage
         :return DFUFault object if the fault was called else None
         """
-        if current_dfu_stage == self.target_dfu_stage:
-            if self._first_call_time is None:
-                self._first_call_time = time()
-            self._elapsed_time += time() - self._first_call_time
-            if self.delay_s is None or (self._elapsed_time >= self.delay_s and not self.called):
+        if current_dfu_stage.name == self.target_dfu_stage.name:
+            if current_dfu_stage.progress >= self.target_dfu_stage.progress and not self.called:
                 if self.callback_function is not None:
                     self.callback_function()
                 self.called = True
@@ -69,45 +60,28 @@ class DFUFaultsFactory:
     """ Factory class used to create specific DFU Faults """
 
     @staticmethod
-    def create_crc_validation_fault(target_dfu_stage: DFUStage, delay_s: Optional[float] = 0,
+    def create_crc_validation_fault(target_dfu_stage: DFUStage,
                                     callback_function: Optional[Callable] = None) -> DFUFault:
         """
         Create fault that simulates CRC Validation Error.
 
-        :param target_dfu_stage: desired DFU stage during which the fault should be generated
-        :param delay_s: delay in seconds (counted from first possible fault call in the target DFU stage) after which
-                        fault should be generated. None to generate fault on every possible call (permanent fault).
+        :param target_dfu_stage: desired DFU stage (name and progress) during which the fault should be generated
         :param callback_function: function that will be called when fault should occur
         :return DFUFault object with defined CRC_VALIDATION fault details
         """
-        return DFUFault(DFUFaultType.CRC_VALIDATION, target_dfu_stage, delay_s, callback_function)
+        return DFUFault(DFUFaultType.CRC_VALIDATION, target_dfu_stage, callback_function)
 
     @staticmethod
-    def create_power_off_fault(target_dfu_stage: DFUStage, delay_s: float, power_cycle_callback: Callable) -> DFUFault:
-        """
-        Create fault that simulates Power Off Error.
-
-        :param target_dfu_stage: desired DFU stage during which the fault should be generated
-        :param delay_s: delay in seconds (counted from first possible fault call in the target DFU stage) after which
-                        fault should be generated. None to generate fault on every possible call (permanent fault).
-        :param power_cycle_callback: power cycle function callback that will be called when fault should occur
-        :return DFUFault object with defined POWER_OFF fault details
-        """
-        return DFUFault(DFUFaultType.POWER_OFF, target_dfu_stage, delay_s, power_cycle_callback)
-
-    @staticmethod
-    def create_abort_fault(target_dfu_stage: DFUStage, delay_s: Optional[float] = 0,
+    def create_abort_fault(target_dfu_stage: DFUStage,
                            callback_function: Optional[Callable] = None) -> DFUFault:
         """
         Create fault that simulates aborting the DFU.
 
-        :param target_dfu_stage: desired DFU stage during which the fault should be generated
-        :param delay_s: delay in seconds (counted from first possible fault call in the target DFU stage) after which
-                        fault should be generated. None to generate fault on every possible call (permanent fault).
+        :param target_dfu_stage: desired DFU stage (name and progress) during which the fault should be generated
         :param callback_function: function that will be called when fault should occur
         :return DFUFault object with defined ABORT fault details
         """
-        return DFUFault(DFUFaultType.ABORT, target_dfu_stage, delay_s, callback_function)
+        return DFUFault(DFUFaultType.ABORT, target_dfu_stage, callback_function)
 
 
 class DFUFaultManager:
@@ -140,7 +114,7 @@ class DFUFaultManager:
         are returned and the DFU controller should raise an error.
 
         :param fault_type: fault type that should be called. E.g. DfuFaultType.CRC_VALIDATION
-        :param current_dfu_stage: Current DFU Stage
+        :param current_dfu_stage: Current DFU Stage (name and progress)
         :return DFUFault object if the fault was called else None
         """
         fault = self._get_fault(fault_type)

--- a/nordicsemi/dfu/dfu_faults.py
+++ b/nordicsemi/dfu/dfu_faults.py
@@ -7,6 +7,8 @@ from typing import Callable, Optional
 class DFUFaultType(Enum):
     """ Enumerator class representing all available types of fault """
     CRC_VALIDATION = "CRC VALIDATION"
+    POWER_OFF = "POWER OFF"
+    ABORT = "ABORT"
 
 
 class DFUStage(Enum):
@@ -80,6 +82,33 @@ class DFUFaultsFactory:
         """
         return DFUFault(DFUFaultType.CRC_VALIDATION, target_dfu_stage, delay_s, callback_function)
 
+    @staticmethod
+    def power_off_fault(target_dfu_stage: DFUStage, delay_s: float, power_cycle_callback: Callable) -> DFUFault:
+        """
+        Create fault that simulates Power Off Error.
+
+        :param target_dfu_stage: desired DFU stage during which the fault should be generated
+        :param delay_s: delay in seconds (counted from first possible fault call in the target DFU stage) after which
+                        fault should be generated. None to generate fault on every possible call (permanent fault).
+        :param power_cycle_callback: power cycle function callback that will be called when fault should occur
+        :return DFUFault object with defined POWER_OFF fault details
+        """
+        return DFUFault(DFUFaultType.POWER_OFF, target_dfu_stage, delay_s, power_cycle_callback)
+
+    @staticmethod
+    def create_abort_fault(target_dfu_stage: DFUStage, delay_s: Optional[float] = 0,
+                           callback_function: Optional[Callable] = None) -> DFUFault:
+        """
+        Create fault that simulates aborting the DFU.
+
+        :param target_dfu_stage: desired DFU stage during which the fault should be generated
+        :param delay_s: delay in seconds (counted from first possible fault call in the target DFU stage) after which
+                        fault should be generated. None to generate fault on every possible call (permanent fault).
+        :param callback_function: function that will be called when fault should occur
+        :return DFUFault object with defined ABORT fault details
+        """
+        return DFUFault(DFUFaultType.ABORT, target_dfu_stage, delay_s, callback_function)
+
 
 class DFUFaultManager:
     """ DFU Fault Manager class for handling simulation of all possible faults during DFU procedure """
@@ -102,6 +131,22 @@ class DFUFaultManager:
         :param fault_type: type of the dfu fault
         """
         return self.dfu_faults.get(fault_type, None)
+
+    def on_fault(self, fault_type: DFUFaultType, current_dfu_stage: DFUStage):
+        """
+        Function that should be called on fault conditions.
+        NOTE: This function does not simulate the exact fault but only provides the information if the fault should
+        be called on the DFU controller side. This means that if the fault conditions are met then the fault details
+        are returned and the DFU controller should raise an error.
+
+        :param fault_type: fault type that should be called. E.g. DfuFaultType.CRC_VALIDATION
+        :param current_dfu_stage: Current DFU Stage
+        :return DFUFault object if the fault was called else None
+        """
+        fault = self._get_fault(fault_type)
+        if fault is not None:
+            return fault.call_fault(current_dfu_stage)
+        return None
 
     def on_crc_validation(self, current_dfu_stage: DFUStage) -> Optional[DFUFault]:
         """

--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -45,7 +45,7 @@ import struct
 import logging
 import binascii
 
-from nordicsemi.dfu.dfu_faults import DFUFaultManager, DFUStage
+from nordicsemi.dfu.dfu_faults import DFUFaultManager, DFUStage, DFUFaultType
 from nordicsemi.dfu.dfu_transport   import DfuTransport, DfuEvent
 from pc_ble_driver_py.exceptions    import NordicSemiException, IllegalStateException
 from pc_ble_driver_py.ble_driver    import BLEDriver, BLEDriverObserver, BLEEnableParams, BLEUUIDBase, BLEGapSecKDist, BLEGapSecParams, \
@@ -64,6 +64,20 @@ nrf_sd_ble_api_ver = config.sd_api_ver_get()
 class ValidationException(NordicSemiException):
     """"
     Exception used when validation failed
+    """
+    pass
+
+
+class PowerOffException(NordicSemiException):
+    """"
+    Exception used when DFU is aborted because of the Power Off
+    """
+    pass
+
+
+class AbortException(NordicSemiException):
+    """"
+    Exception used when DFU is aborted
     """
     pass
 
@@ -621,7 +635,24 @@ class DfuTransportBle(DfuTransport):
     def __handle_fault_manager_crc_validation_fault(self):
         """ Handles simulation of CRC Validation Fault """
         if self.dfu_fault_manager is not None:
-            fault = self.dfu_fault_manager.on_crc_validation(self.current_dfu_stage)
+            fault = self.dfu_fault_manager.on_fault(fault_type=DFUFaultType.CRC_VALIDATION,
+                                                    current_dfu_stage=self.current_dfu_stage)
+            if fault is not None:
+                raise AbortException("Simulating DFU Abort Fault by Power Off")
+
+    def __handle_power_off_fault(self):
+        """ Handles simulation of CRC Validation Fault """
+        if self.dfu_fault_manager is not None:
+            fault = self.dfu_fault_manager.on_fault(fault_type=DFUFaultType.POWER_OFF,
+                                                    current_dfu_stage=self.current_dfu_stage)
+            if fault is not None:
+                raise PowerOffException("Simulating DFU Abort Fault by Power Off")
+
+    def __handle_abort_fault(self):
+        """ Handles simulation of CRC Validation Fault """
+        if self.dfu_fault_manager is not None:
+            fault = self.dfu_fault_manager.on_fault(fault_type=DFUFaultType.ABORT,
+                                                    current_dfu_stage=self.current_dfu_stage)
             if fault is not None:
                 raise ValidationException("Simulating CRC Validation Fault")
 

--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -551,6 +551,8 @@ class DfuTransportBle(DfuTransport):
             try:
                 self.__create_command(len(init_packet))
                 self.__stream_data(data=init_packet)
+                self.__handle_fault_manager_power_off_fault()
+                self.__handle_fault_manager_abort_fault()
                 self.__execute()
             except ValidationException as error:
                 logger.critical(f"BLE: ValidationException Error occurred during init packet send at "
@@ -604,6 +606,8 @@ class DfuTransportBle(DfuTransport):
                 try:
                     self.__create_data(len(data))
                     response['crc'] = self.__stream_data(data=data, crc=response['crc'], offset=current_offset)
+                    self.__handle_fault_manager_power_off_fault()
+                    self.__handle_fault_manager_abort_fault()
                     self.__execute()
                 except ValidationException as error:
                     logger.critical("BLE: ValidationException Error occurred during sending firmware chunk at "
@@ -638,23 +642,23 @@ class DfuTransportBle(DfuTransport):
             fault = self.dfu_fault_manager.on_fault(fault_type=DFUFaultType.CRC_VALIDATION,
                                                     current_dfu_stage=self.current_dfu_stage)
             if fault is not None:
-                raise AbortException("Simulating DFU Abort Fault by Power Off")
+                raise ValidationException("Simulating CRC Validation Fault")
 
-    def __handle_power_off_fault(self):
-        """ Handles simulation of CRC Validation Fault """
+    def __handle_fault_manager_power_off_fault(self):
+        """ Handles simulation of DFU Abort by the Power Off """
         if self.dfu_fault_manager is not None:
             fault = self.dfu_fault_manager.on_fault(fault_type=DFUFaultType.POWER_OFF,
                                                     current_dfu_stage=self.current_dfu_stage)
             if fault is not None:
-                raise PowerOffException("Simulating DFU Abort Fault by Power Off")
+                raise PowerOffException("Simulating DFU Abort by Power Off")
 
-    def __handle_abort_fault(self):
-        """ Handles simulation of CRC Validation Fault """
+    def __handle_fault_manager_abort_fault(self):
+        """ Handles simulation of DFU Abort """
         if self.dfu_fault_manager is not None:
             fault = self.dfu_fault_manager.on_fault(fault_type=DFUFaultType.ABORT,
                                                     current_dfu_stage=self.current_dfu_stage)
             if fault is not None:
-                raise ValidationException("Simulating CRC Validation Fault")
+                raise AbortException("Simulating DFU Abort")
 
     def __set_prn(self):
         logger.debug("BLE: Set Packet Receipt Notification {}".format(self.prn))

--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -45,7 +45,7 @@ import struct
 import logging
 import binascii
 
-from nordicsemi.dfu.dfu_faults import DFUFaultManager, DFUStage, DFUFaultType
+from nordicsemi.dfu.dfu_faults import DFUFaultManager, DFUStage, DFUStageName, DFUFaultType
 from nordicsemi.dfu.dfu_transport   import DfuTransport, DfuEvent
 from pc_ble_driver_py.exceptions    import NordicSemiException, IllegalStateException
 from pc_ble_driver_py.ble_driver    import BLEDriver, BLEDriverObserver, BLEEnableParams, BLEUUIDBase, BLEGapSecKDist, BLEGapSecParams, \
@@ -62,24 +62,11 @@ nrf_sd_ble_api_ver = config.sd_api_ver_get()
 
 
 class ValidationException(NordicSemiException):
-    """"
-    Exception used when validation failed
-    """
-    pass
-
-
-class PowerOffException(NordicSemiException):
-    """"
-    Exception used when DFU is aborted because of the Power Off
-    """
-    pass
+    """ Exception used when validation failed """
 
 
 class AbortException(NordicSemiException):
-    """"
-    Exception used when DFU is aborted
-    """
-    pass
+    """ Exception used when DFU is aborted """
 
 
 class DFUAdapter(BLEDriverObserver, BLEAdapterObserver):
@@ -481,7 +468,7 @@ class DfuTransportBle(DfuTransport):
         self.prn                = prn
         self.bluez              = bluez
         self.dfu_fault_manager  = dfu_fault_manager
-        self.current_dfu_stage  = None
+        self.current_dfu_stage  = DFUStage()
 
         self.bonded             = False
         self.keyset             = None
@@ -547,13 +534,15 @@ class DfuTransportBle(DfuTransport):
         if try_to_recover():
             return
 
+        self.current_dfu_stage.name = DFUStageName.INIT_PACKET
+        self.current_dfu_stage.progress = 0
         for r in range(DfuTransportBle.RETRIES_NUMBER):
             try:
                 self.__create_command(len(init_packet))
                 self.__stream_data(data=init_packet)
-                self.__handle_fault_manager_power_off_fault()
                 self.__handle_fault_manager_abort_fault()
                 self.__execute()
+                self.current_dfu_stage.progress = 100
             except ValidationException as error:
                 logger.critical(f"BLE: ValidationException Error occurred during init packet send at "
                                 f"attempt {r + 1}: {error}")
@@ -561,6 +550,7 @@ class DfuTransportBle(DfuTransport):
             break
         else:
             raise NordicSemiException("Failed to send init packet")
+        self.__handle_fault_manager_abort_fault()
 
     def send_firmware(self, firmware):
         def try_to_recover():
@@ -599,6 +589,8 @@ class DfuTransportBle(DfuTransport):
         response['crc'] = 0
         try_to_recover()
 
+        self.current_dfu_stage.name = DFUStageName.FIRMWARE_UPDATE
+        self.current_dfu_stage.progress = 0
         for current_offset in range(response['offset'], len(firmware), response['max_size']):
             logger.debug(f"Sending firmware chunk from offset: {current_offset}")
             data = firmware[current_offset:current_offset+response['max_size']]
@@ -606,7 +598,6 @@ class DfuTransportBle(DfuTransport):
                 try:
                     self.__create_data(len(data))
                     response['crc'] = self.__stream_data(data=data, crc=response['crc'], offset=current_offset)
-                    self.__handle_fault_manager_power_off_fault()
                     self.__handle_fault_manager_abort_fault()
                     self.__execute()
                 except ValidationException as error:
@@ -634,7 +625,11 @@ class DfuTransportBle(DfuTransport):
                 break
             else:
                 raise NordicSemiException("Failed to send firmware")
-            self._send_event(event_type=DfuEvent.PROGRESS_EVENT, progress=len(data))
+            self.current_dfu_stage.progress = min(((current_offset + response['max_size']) / len(firmware)) * 100, 100)
+            logger.debug(f"Current progress: {self.current_dfu_stage.progress:.2f} %")
+            self._send_event(event_type=DfuEvent.PROGRESS_EVENT, progress=self.current_dfu_stage.progress)
+
+        self.__handle_fault_manager_abort_fault()
 
     def __handle_fault_manager_crc_validation_fault(self):
         """ Handles simulation of CRC Validation Fault """
@@ -643,14 +638,6 @@ class DfuTransportBle(DfuTransport):
                                                     current_dfu_stage=self.current_dfu_stage)
             if fault is not None:
                 raise ValidationException("Simulating CRC Validation Fault")
-
-    def __handle_fault_manager_power_off_fault(self):
-        """ Handles simulation of DFU Abort by the Power Off """
-        if self.dfu_fault_manager is not None:
-            fault = self.dfu_fault_manager.on_fault(fault_type=DFUFaultType.POWER_OFF,
-                                                    current_dfu_stage=self.current_dfu_stage)
-            if fault is not None:
-                raise PowerOffException("Simulating DFU Abort by Power Off")
 
     def __handle_fault_manager_abort_fault(self):
         """ Handles simulation of DFU Abort """
@@ -692,11 +679,9 @@ class DfuTransportBle(DfuTransport):
         self.__get_response(DfuTransportBle.OP_CODE['Execute'])
 
     def __select_command(self):
-        self.current_dfu_stage = DFUStage.INIT_PACKET
         return self.__select_object(0x01)
 
     def __select_data(self):
-        self.current_dfu_stage = DFUStage.FIRMWARE_UPDATE
         return self.__select_object(0x02)
 
     def __select_object(self, object_type):

--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -625,7 +625,7 @@ class DfuTransportBle(DfuTransport):
                 break
             else:
                 raise NordicSemiException("Failed to send firmware")
-            self.current_dfu_stage.progress = min(((current_offset + response['max_size']) / len(firmware)) * 100, 100)
+            self.current_dfu_stage.progress = ((current_offset + response['max_size']) / len(firmware)) * 100
             logger.debug(f"Current progress: {self.current_dfu_stage.progress:.2f} %")
             self._send_event(event_type=DfuEvent.PROGRESS_EVENT, progress=self.current_dfu_stage.progress)
 

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.10.dev4"
+NRFUTIL_VERSION = "6.1.10"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.10"
+NRFUTIL_VERSION = "6.1.10.dev3"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.10.dev0"
+NRFUTIL_VERSION = "6.1.10.dev1"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.9"
+NRFUTIL_VERSION = "6.1.10.dev0"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.10.dev1"
+NRFUTIL_VERSION = "6.1.10.dev2"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.10.dev3"
+NRFUTIL_VERSION = "6.1.10.dev4"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.10.dev2"
+NRFUTIL_VERSION = "6.1.10"


### PR DESCRIPTION
This PR adds support for DFU Abort fault. I have also changed the mechanism of faults simulation to use progress (in %) instead of delay (in seconds). Power Off fault can be simulated using abort fault by providing the `power_off` callback function (it will be called before raising an error). 

Confirmed that faults generation works fine on a branch that checks DFU Interrupted scenarios.