### PR TITLE
Ss 10530 dfu improvements

### DIFF
--- a/nordicsemi/dfu/bluez.py
+++ b/nordicsemi/dfu/bluez.py
@@ -531,6 +531,7 @@ class BluezDriver(object):
         :param scan_params: None, scan parameters 
         :param conn_params: BLEGapConnParams, connection parameters
         """
+        self.ble_gap_scan_stop()
         dev = self.devices[address.addr.hex()]
         if dev is None:
             raise RuntimeError("Could not find device with address")
@@ -551,7 +552,6 @@ class BluezDriver(object):
                                      peer_addr = address,
                                      role = BLEGapRoles.periph,
                                      conn_params = conn_params)
-        self.ble_gap_scan_stop()
 
     def ble_gap_disconnect(self, conn_handle):
         """ Disconnect from device.

--- a/nordicsemi/dfu/bluez.py
+++ b/nordicsemi/dfu/bluez.py
@@ -17,7 +17,7 @@ from pc_ble_driver_py.ble_driver import BLEUUID, BLEUUIDBase, BLEGapAddr, BLEAdv
 from pc_ble_driver_py.exceptions import NordicSemiException
 from pc_ble_driver_py.observers import BLEAdapterObserver, BLEDriverObserver
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 BLUEZ_SERVICE = "org.bluez"
 ROOT_OBJ = "/"

--- a/nordicsemi/dfu/bluez.py
+++ b/nordicsemi/dfu/bluez.py
@@ -447,6 +447,8 @@ class BluezConnectionManager(object):
 class BluezDriver(object):
     """ Class is responsible for calling low level operations on BlueZ stack. """
 
+    ESTABLISHING_CONNECTION_TIMEOUT_S = 30
+
     def __init__(self):
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
@@ -529,13 +531,17 @@ class BluezDriver(object):
         :param scan_params: None, scan parameters 
         :param conn_params: BLEGapConnParams, connection parameters
         """
-        self.ble_gap_scan_stop()
         dev = self.devices[address.addr.hex()]
         if dev is None:
             raise RuntimeError("Could not find device with address")
 
-        if not dev.connect():
-            raise RuntimeError("Could not connect to device: {}".format(binascii.hexlify(address.addr)))
+        start_time = time.time()
+        while (time.time() - start_time) < self.ESTABLISHING_CONNECTION_TIMEOUT_S:
+            if dev.connect():
+                break
+        else:
+            raise RuntimeError(f"Could not connect to device : {binascii.hexlify(address.addr)} within "
+                               f"{self.ESTABLISHING_CONNECTION_TIMEOUT_S} s.")
 
         conn_handle = self.conn_manager.create_new_connection(dev)
 
@@ -545,6 +551,7 @@ class BluezDriver(object):
                                      peer_addr = address,
                                      role = BLEGapRoles.periph,
                                      conn_params = conn_params)
+        self.ble_gap_scan_stop()
 
     def ble_gap_disconnect(self, conn_handle):
         """ Disconnect from device.

--- a/nordicsemi/dfu/dfu.py
+++ b/nordicsemi/dfu/dfu.py
@@ -46,7 +46,7 @@ import tempfile
 # Nordic libraries
 from nordicsemi.dfu.package         import Package
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class Dfu:

--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -53,7 +53,7 @@ from pc_ble_driver_py.ble_driver    import BLEDriver, BLEDriverObserver, BLEEnab
 from pc_ble_driver_py.ble_driver    import ATT_MTU_DEFAULT, BLEConfig, BLEConfigConnGatt, BLEConfigConnGap
 from pc_ble_driver_py.ble_adapter   import BLEAdapter, BLEAdapterObserver, EvtSync
 
-logger  = logging.getLogger(__name__)
+logger  = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 from pc_ble_driver_py import config

--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -87,7 +87,7 @@ class DFUAdapter(BLEDriverObserver, BLEAdapterObserver):
     ERROR_CODE_POS        = 2
     LOCAL_ATT_MTU         = 247
 
-    def __init__(self, adapter, bonded=False, keyset=None):
+    def __init__(self, adapter, bonded=False, keyset=None, att_mtu=ATT_MTU_DEFAULT):
         super().__init__()
 
         self.evt_sync           = EvtSync(['connected', 'disconnected', 'sec_params',
@@ -98,7 +98,7 @@ class DFUAdapter(BLEDriverObserver, BLEAdapterObserver):
         self.keyset             = keyset
         self.notifications_q    = queue.Queue()
         self.indication_q       = queue.Queue()
-        self.att_mtu            = ATT_MTU_DEFAULT
+        self.att_mtu            = att_mtu
         self.packet_size        = self.att_mtu - 3
         self.adapter.observer_register(self)
         self.adapter.driver.observer_register(self)
@@ -448,7 +448,7 @@ class DfuTransportBle(DfuTransport):
 
     def __init__(self,
                  serial_port,
-                 att_mtu,
+                 att_mtu=ATT_MTU_DEFAULT,
                  target_device_name=None,
                  target_device_addr=None,
                  baud_rate=1000000,
@@ -485,7 +485,7 @@ class DfuTransportBle(DfuTransport):
         else:
             driver  = DfuBLEDriver(serial_port = self.serial_port, baud_rate   = self.baud_rate)
             adapter = BLEAdapter(driver)
-        self.dfu_adapter = DFUAdapter(adapter=adapter, bonded=self.bonded, keyset=self.keyset)
+        self.dfu_adapter = DFUAdapter(adapter=adapter, bonded=self.bonded, keyset=self.keyset, att_mtu=self.att_mtu)
         self.dfu_adapter.open()
         self.target_device_name, self.target_device_addr = self.dfu_adapter.connect(
                                                         target_device_name = self.target_device_name,

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.11.dev5"
+NRFUTIL_VERSION = "6.1.11.dev6"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.10"
+NRFUTIL_VERSION = "6.1.11.dev4"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.11.dev4"
+NRFUTIL_VERSION = "6.1.11.dev5"

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.11.dev6"
+NRFUTIL_VERSION = "6.1.11"

--- a/sca_pipeline.groovy
+++ b/sca_pipeline.groovy
@@ -7,7 +7,7 @@
 // During the first launch, you have to enter ALTERNATIVE_VERSION parameter.
 
 
-@Library('JenkinsMain@2.19.17')_
+@Library('JenkinsMain@2.19.21')_
 
 
 pipelinePythonSCA(


### PR DESCRIPTION
Implemented the following improvements:
- added support for using the configurable value of ATT MTU size. It was hardcoded to 23 bytes. FW tests will use ATT MTU size = 50 to speed up the data transfer (by about 20%).
- added retries for establishing the connection. I was planning to add a 2nd improvement (to keep the scanner on while establishing the connection) but this is not working on DFU dongles in our CIs).
- added more logs by using `logging.getLogger()` instead of `logging.getLogger(__name__)`. The second option does not work with behave logging.

DFU test results on Jenkins:
https://jenkins.silvair.lan/job/FW-Test/job/SS-10530_nrfutil_improvements/5/