### PR TITLE
SS-11018 Adjusted dfu_transport_ble.py implementation to connect the …

### DIFF
--- a/nordicsemi/dfu/dfu_transport_ble.py
+++ b/nordicsemi/dfu/dfu_transport_ble.py
@@ -399,7 +399,8 @@ class DFUAdapter(BLEDriverObserver, BLEAdapterObserver):
             # set with BLEConfigConnGatt (that implicitly operates
             # on connections with tag 1) to allow for larger MTU.
             self.adapter.connect(address=peer_addr,
-                                 conn_params=self.conn_params)
+                                 conn_params=self.conn_params,
+                                 tag=1)
             # store the address for subsequent connections
             self.target_device_addr = address_string
             self.target_device_addr_type = peer_addr

--- a/nordicsemi/version.py
+++ b/nordicsemi/version.py
@@ -37,4 +37,4 @@
 
 """ Version definition for nrfutil. """
 
-NRFUTIL_VERSION = "6.1.11"
+NRFUTIL_VERSION = "6.1.12"


### PR DESCRIPTION
…same way as the original version from Nordic GitHub
This PR adds a missing tag parameter to the connect() function.
The specific value of the tag parameter is mentioned in the comment above and also is present in the Nordic version. 